### PR TITLE
Add test for ExpenseForm submission

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,8 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
+  moduleNameMapper: {
+    '\\.(css|less|scss)$': 'identity-obj-proxy'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "firebase": "^11.7.1",
@@ -30,6 +31,13 @@
     "globals": "^16.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.3",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.3.1",
+    "@testing-library/user-event": "^14.4.3",
+    "identity-obj-proxy": "^3.0.0"
   }
 }

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/components/__tests__/ExpenseForm.test.tsx
+++ b/src/components/__tests__/ExpenseForm.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ExpenseForm from '../ExpenseForm';
+import { useExpenses } from '../../context/ExpenseContext';
+import { useAuth } from '../../context/AuthContext';
+import {
+  addDoc,
+  collection,
+  getDoc,
+  getDocs,
+  query,
+  where,
+  doc,
+} from 'firebase/firestore';
+
+jest.mock('../../context/ExpenseContext');
+jest.mock('../../context/AuthContext');
+jest.mock('firebase/firestore');
+
+describe('ExpenseForm', () => {
+  const mockDispatch = jest.fn();
+  beforeEach(() => {
+    (useExpenses as jest.Mock).mockReturnValue({ dispatch: mockDispatch });
+    (useAuth as jest.Mock).mockReturnValue({ user: { uid: '1', displayName: 'Test User' } });
+
+    (addDoc as jest.Mock).mockResolvedValue({ id: 'doc1' });
+    (collection as jest.Mock).mockReturnValue('collection');
+    (getDoc as jest.Mock).mockResolvedValue({ data: () => ({ members: ['1'] }) });
+    (getDocs as jest.Mock).mockResolvedValue({ docs: [] });
+    (query as jest.Mock).mockReturnValue('query');
+    (where as jest.Mock).mockReturnValue('where');
+    (doc as jest.Mock).mockReturnValue('doc');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dispatches ADD_EXPENSE on valid submit', async () => {
+    render(<ExpenseForm />);
+
+    userEvent.type(screen.getByPlaceholderText(/Description/i), 'Coffee');
+    userEvent.type(screen.getByPlaceholderText(/Amount/i), '5');
+
+    userEvent.click(screen.getByRole('button', { name: /Add/i }));
+
+    await waitFor(() => expect(mockDispatch).toHaveBeenCalled());
+    expect(mockDispatch.mock.calls[0][0].type).toBe('ADD_EXPENSE');
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["jest", "node"],
+    "noEmit": true
+  },
+  "include": ["src", "setupTests.ts"]
+}


### PR DESCRIPTION
## Summary
- add Jest and React Testing Library configuration
- create ExpenseForm test with mocked context and Firebase

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517b2eb02c832fa89c39e517768d92