### PR TITLE
Avoid double provider nesting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,4 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { AuthProvider } from './context/AuthContext';
-import { ExpenseProvider } from './context/ExpenseContext';
 import AddExpensePage from './pages/AddExpensePage';
 import ExpenseListPage from './pages/ExpenseListPage';
 import ExpenseCalendarPage from './pages/ExpenseCalendarPage';
@@ -11,22 +9,18 @@ import PrivateRoute from './routes/PrivateRoute';
 import RegisterPage from './pages/RegisterPage';
 function App() {
   return (
-    <AuthProvider>
-      <ExpenseProvider>
-        <Router>
-          <Routes>
+    <Router>
+      <Routes>
          
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/" element={<Navigate to="/dashboard" />} />
-            <Route path="/dashboard" element={<PrivateRoute><DashboardPage /></PrivateRoute>} />
-            <Route path="/add-expense" element={<PrivateRoute><AddExpensePage /></PrivateRoute>} />
-            <Route path="/expenses" element={<PrivateRoute><ExpenseListPage /></PrivateRoute>} />
-            <Route path="/calendar" element={<PrivateRoute><ExpenseCalendarPage /></PrivateRoute>} />
-            <Route path="/groups" element={<PrivateRoute><GroupManagementPage /></PrivateRoute>} />
-          </Routes>
-        </Router>
-      </ExpenseProvider>
-    </AuthProvider>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/" element={<Navigate to="/dashboard" />} />
+        <Route path="/dashboard" element={<PrivateRoute><DashboardPage /></PrivateRoute>} />
+        <Route path="/add-expense" element={<PrivateRoute><AddExpensePage /></PrivateRoute>} />
+        <Route path="/expenses" element={<PrivateRoute><ExpenseListPage /></PrivateRoute>} />
+        <Route path="/calendar" element={<PrivateRoute><ExpenseCalendarPage /></PrivateRoute>} />
+        <Route path="/groups" element={<PrivateRoute><GroupManagementPage /></PrivateRoute>} />
+      </Routes>
+    </Router>
   );
 }
 


### PR DESCRIPTION
## Summary
- remove nested AuthProvider and ExpenseProvider from App

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react-router-dom' or its types)*

------
https://chatgpt.com/codex/tasks/task_e_68517b2c259c832f9bf87240d69102b0