### PR TITLE
Fix Firebase storage bucket domain

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -7,7 +7,7 @@ const firebaseConfig = {
     apiKey: "AIzaSyBwNzDCcMqNyIo-JYziKy3oTaiRk7gzdu8",
     authDomain: "expensetracker-a9029.firebaseapp.com",
     projectId: "expensetracker-a9029",
-    storageBucket: "expensetracker-a9029.firebasestorage.app",
+    storageBucket: "expensetracker-a9029.appspot.com",
     messagingSenderId: "795748726287",
     appId: "1:795748726287:web:951da454fc6064c430157a",
     measurementId: "G-8B86W52N5P"


### PR DESCRIPTION
## Summary
- correct Firebase storageBucket domain

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68517b280cd0832f91a04ea422614275